### PR TITLE
add an extend command to complement merge

### DIFF
--- a/clidantic/core.py
+++ b/clidantic/core.py
@@ -182,3 +182,15 @@ class Parser:
             hasattr(cli, "name") and cli.name is not None for cli in subgroups
         ), "Nested parsers must have a name"
         return cls(name=name, subgroups=subgroups)
+    
+    def extend(self, *subgroups: Tuple["Parser", ...]) -> None:
+        """Extends the current parser with additional subgroups.
+        
+        Args:
+            subgroups (Tuple[Parser, ...]): variable sequence of additional subgroups.
+        """
+        assert subgroups is not None and len(subgroups) > 0, "Provide at least one Parser to extend"
+
+        for subgroup in subgroups:
+            assert hasattr(subgroup, "name") and subgroup.name is not None, "Nested parsers must have a name"
+            self.subgroups.append(subgroup)


### PR DESCRIPTION
This is more of a starting point for discussion than a serious attempt at a merge currently. 

We are considering using this lib to build a reusable CLI with a plugin architecture. One of the ergonomics of the existing  Parser.merge() method that is exposed is not very suitable to this currently.

Currently my setup is as follows:

I have a top level project where I instantiate a parser, and in various other projects, I declare entrypoints in these other projects which are then exposed to the top level cli and merged in as subgroups. 

My code to do that looks sort of like this:

```python

cli = Parser(name= "cli")

# Register the installed plugin commands into the main cli
for command_group in gctx.plugin_manager.get_command_groups():
    print(f"Registering command group: {command_group.name}")
    cli = Parser.merge(cli, command_group)

# cli is now an empty command group that holds two subcommands, cli and whatever was in "command_group"
```

This isn't really how the merge() function works though. Each time we call merge, we are creating new, nameless parser (unless you name it) to hold the groups (parsers) supplied to merge as subcommands. But really what we want to do is have a top level Parser that we can add aribtrary subcommands to, and still have that same Parser. So I propose this extend() method to achieve that. Now the code is a bit more nice with this approach:


```python

cli = Parser(name= "cli")

# Register the installed plugin commands into the main cli
for command_group in gctx.plugin_manager.get_command_groups():
    logger.debug(f"Registering command group: {command_group.name}")
    cli.extend(command_group)

# Register command groups local to our top level cli into the main cli
cli.extend(plugin)

# cli is a top level command with two subcommand groups, "plugin" and whatever was in "command_group"
```

If you agree with this approach I'm happy to shore it up and add some testing around it