### PR TITLE
tox and py312 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         poetry-version: ["1.1.12"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Typing :: Typed",
   "Intended Audience :: Information Technology",
   "Intended Audience :: Science/Research",
@@ -26,7 +28,7 @@ click = "^8.1.0"
 pydantic = "^1.9.0"
 python = "^3.8"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^22.6.0"
 coverage = "^6.1.2"
 flake8 = "^4.0.1"
@@ -38,6 +40,7 @@ mypy = "^0.910"
 pytest = "^6.2.5"
 pytest-cov = "^3.0.0"
 pytest-xdist = "^2.5.0"
+tox = "^4.14.2"
 
 [tool.poetry-dynamic-versioning]
 enable = true
@@ -66,3 +69,35 @@ testpaths = ["tests"]
 [build-system]
 build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+isolated_build = true
+skipsdist = true
+envlist =
+    py38
+    py39
+    py310
+    py311
+    py312
+    doc
+    coverage
+
+[testenv]
+allowlist_externals = poetry
+commands =
+    poetry install
+    poetry run pytest {posargs}
+
+[testenv:doc]
+commands =
+    poetry install
+    poetry run mkdocs build
+
+[testenv:coverage]
+commands =
+    poetry install
+    poetry run pytest --cov --cov-report term:skip-covered {posargs:-n auto}
+    poetry run coverage html
+"""


### PR DESCRIPTION
This PR add a minimal tox setup to run unit tests with all the current supported python versions, and also adds py311 and py312 GHA support.

Currently, py38 and py39 tests are failing because of the use of the `inspect.signature` `eval_str` argument that was only [introduced in python 3.10](https://docs.python.org/3/library/inspect.html#inspect.signature), but I suppose the fix can be the object of another PR.

https://github.com/edornd/clidantic/blob/62b861c51cc05354d7eeb6aa784b6da00682a771/clidantic/core.py#L144